### PR TITLE
fix: 배포 후 이미지 경로 수정

### DIFF
--- a/src/components/common/BackButton.tsx
+++ b/src/components/common/BackButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import backIcon from '../../assets/back.png';
 import { StyledBackButton } from '@/styles/common/BackButton.styles';
 
 interface BackButtonProps {
@@ -6,7 +7,11 @@ interface BackButtonProps {
 }
 
 const BackButton: React.FC<BackButtonProps> = ({ onClick }) => {
-  return <StyledBackButton onClick={onClick} aria-label="뒤로 가기" />;
+  return (
+    <StyledBackButton onClick={onClick} aria-label="뒤로 가기">
+      <img src={backIcon} alt="Back" />
+    </StyledBackButton>
+  );
 };
 
 export default BackButton;

--- a/src/components/common/Search.tsx
+++ b/src/components/common/Search.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import * as S from '../../styles/common/Search.styles';
 import { Place } from '@/types/map/place';
 import { koreanMatch } from '@/utils/searchUtils';
+import searchIcon from '../../assets/search.png';
 
 interface SearchProps {
   placeholder?: string;
@@ -119,7 +120,7 @@ const Search: React.FC<SearchProps> = ({
 
   return (
     <S.SearchContainer className="search-container">
-      <S.SearchIcon onClick={handleSubmit} />
+      <S.SearchIcon src={searchIcon} alt="Search" onClick={handleSubmit} />
       <S.SearchInput
         type="text"
         placeholder={placeholder}

--- a/src/components/map/LeftContainter.tsx
+++ b/src/components/map/LeftContainter.tsx
@@ -9,6 +9,7 @@ import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/hooks/reduxHooks';
 import { openLoginModal } from '@/store/slices/modalSlice';
 import { RouteSource } from '@/types/map/routeSource';
+import searchDeleteIcon from '../../assets/search_delete.png';
 
 interface LeftContainerProps {
   onPlaceSelect?: (place: Place) => void;
@@ -88,7 +89,9 @@ const LeftContainer: React.FC<LeftContainerProps> = ({ onPlaceSelect, onFavorite
     const displayText = search.length > MAX_LENGTH ? `${search.slice(0, MAX_LENGTH)}...` : search;
     return (
       <S.RecentSearchItem>
-        <S.DeleteButton onClick={onDelete} />
+        <S.DeleteButton onClick={onDelete}>
+          <img src={searchDeleteIcon} alt="Delete" />
+        </S.DeleteButton>
         <S.SearchText>{displayText}</S.SearchText>
       </S.RecentSearchItem>
     );

--- a/src/components/map/LocationDetail.tsx
+++ b/src/components/map/LocationDetail.tsx
@@ -8,6 +8,10 @@ import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/hooks/reduxHooks';
 import { openLoginModal } from '@/store/slices/modalSlice';
 import { usePlaceLikeDetail } from '@/hooks/map/usePlaceLikeDetail';
+import nextIcon from '../../assets/next.png';
+import logoRepeat from '../../assets/logorepeat.png';
+import favIcon from '../../assets/fav.png';
+import favActiveIcon from '../../assets/fav2.png';
 
 interface LocationDetailProps {
   location: LocationDetailType;
@@ -16,7 +20,7 @@ interface LocationDetailProps {
   placeLikeId?: number;
 }
 
-const DEFAULT_IMAGE = '/src/assets/logorepeat.png';
+const DEFAULT_IMAGE = logoRepeat;
 
 const LocationDetail: React.FC<LocationDetailProps> = ({
   location,
@@ -71,22 +75,27 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
   };
 
   const imageSource = useMemo(() => {
+    console.log('PlaceDetails in LocationDetail:', placeDetails);
+    console.log('Current photoUrl:', placeDetails?.photoUrl);
+
     // 1. 먼저 이미지 로드 실패한 경우
     if (imageLoadFailed) {
-      return '/src/assets/logorepeat.png';
+      console.log('Image load failed, using default');
+      return logoRepeat;
     }
 
     // 2. placeDetails가 있고 photoUrl이 있는 경우
     if (placeDetails?.photoUrl) {
+      console.log('Using placeDetails photoUrl');
       // Google Places API의 특수 URL인 경우 기본 이미지 사용
       if (placeDetails.photoUrl.includes('PhotoService.GetPhoto')) {
-        return '/src/assets/logorepeat.png';
+        return logoRepeat;
       }
       return placeDetails.photoUrl;
     }
-
+    console.log('No valid photo URL found, using default');
     // 3. 그 외의 경우 기본 이미지 사용
-    return '/src/assets/logorepeat.png';
+    return logoRepeat;
   }, [placeDetails?.photoUrl, imageLoadFailed]);
 
   const handleImageError = useCallback(() => {
@@ -122,7 +131,7 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
       />
       {allPlaces.length > 1 && (
         <S.PaginationButton onClick={handleNextLocation}>
-          <img src="/src/assets/next.png" alt="next" />
+          <img src={nextIcon} alt="next" />
         </S.PaginationButton>
       )}
       <S.Title>
@@ -139,7 +148,7 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
       </S.TagContainer>
 
       <S.FavButton onClick={handleFavClick}>
-        <img src={isFavorited ? '/src/assets/fav2.png' : '/src/assets/fav.png'} alt="favorite" />
+        <img src={isFavorited ? favActiveIcon : favIcon} alt="favorite" />
       </S.FavButton>
 
       <S.ReviewButton onClick={handleReviewClick}>명소 후기</S.ReviewButton>

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useCallback, forwardRef } from 'react';
 import * as S from '../../styles/map/MapContainer.styles';
 import { RouteLocation } from '../../types/map/route';
 import { getPlaceDetails, PlaceDetails } from '../../utils/mapUtils';
+import pinIcon from '../../assets/pin.png';
 
 // interface MapContainerProps {
 //   apiKey: string;
@@ -171,7 +172,7 @@ const MapContainer = forwardRef<google.maps.Map | null, MapContainerProps>(
           position: { lat: location.latitude, lng: location.longitude },
           map: mapInstance.current,
           icon: {
-            url: '/src/assets/pin.png',
+            url: pinIcon,
             scaledSize: new window.google.maps.Size(initialSize.width * 2, initialSize.height * 2),
           },
         });
@@ -181,7 +182,7 @@ const MapContainer = forwardRef<google.maps.Map | null, MapContainerProps>(
           const newZoom = mapInstance.current?.getZoom() || 12;
           const newSize = getMarkerSize(newZoom);
           marker.setIcon({
-            url: '/src/assets/pin.png',
+            url: pinIcon,
             scaledSize: new window.google.maps.Size(newSize.width * 2, newSize.height * 2),
           });
         });

--- a/src/components/map/RouteLeftContainer.tsx
+++ b/src/components/map/RouteLeftContainer.tsx
@@ -28,6 +28,7 @@ import { openLoginModal } from '@/store/slices/modalSlice';
 import { updateRoute } from '@/api/map/routeUpdate';
 import { saveCustomRoute } from '@/api/map/routeSave';
 import { toast } from 'react-toastify';
+import edit from '../../assets/edit.png';
 
 interface RouteLeftContainerProps {
   initialLocations: RouteLocation[];
@@ -245,7 +246,7 @@ const RouteLeftContainer: React.FC<RouteLeftContainerProps> = ({
       ) : (
         <S.Description>
           <TruncatedDescription text={routeData.description} />
-          <S.EditButton src="/src/assets/edit.png" alt="edit" onClick={() => setIsEditing(true)} />
+          <S.EditButton src={edit} alt="edit" onClick={() => setIsEditing(true)} />
         </S.Description>
       )}
       <S.Divider />

--- a/src/styles/common/BackButton.styles.ts
+++ b/src/styles/common/BackButton.styles.ts
@@ -2,16 +2,23 @@ import styled from 'styled-components';
 
 export const StyledBackButton = styled.button`
   position: absolute;
-  left: 4px; // 5 * 0.8
-  top: 12px; // 15 * 0.8
-  width: 27px; // 34 * 0.8
-  height: 17.7px; // 22.1 * 0.8
-  border: 1.2px solid #d1c1ff; // 1.5 * 0.8
+  left: 4px;
+  top: 12px;
+  width: 27px;
+  height: 17.7px;
   border: none;
-  background: url('/src/assets/back.png') no-repeat center / contain;
   cursor: pointer;
   padding: 0;
   background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 
   &:focus {
     outline: none;

--- a/src/styles/common/Search.styles.ts
+++ b/src/styles/common/Search.styles.ts
@@ -26,13 +26,12 @@ export const SearchInput = styled.input`
   }
 `;
 
-export const SearchIcon = styled.div`
+export const SearchIcon = styled.img`
   position: absolute;
   left: 8px;
   top: 20px;
   width: 20px;
   height: 20px;
-  background: url('/src/assets/search.png') no-repeat center / contain;
   cursor: pointer;
 `;
 

--- a/src/styles/map/LeftContainer.styles.ts
+++ b/src/styles/map/LeftContainer.styles.ts
@@ -137,7 +137,6 @@ export const DeleteButton = styled.button`
   border: none;
   outline: none;
   cursor: pointer;
-  background: url('/src/assets/search_delete.png') no-repeat center / contain;
   padding: 0;
   display: flex;
   align-items: center;

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,3 +1,5 @@
+import logoRepeat from '../assets/logorepeat.png';
+
 export interface PlaceDetails {
   address: string;
   photoUrl?: string;
@@ -58,30 +60,58 @@ export const getPlaceDetails = async (
 
     console.log('Places API search results:', places);
 
+    // if (places && places.length > 0) {
+    //   name = places[0].name;
+    //   placeId = places[0].place_id;
+
+    //   if (places[0].photos && places[0].photos.length > 0) {
+    //     try {
+    //       const tempUrl = places[0].photos[0].getUrl();
+    //       // URL에서 photo reference 추출
+    //       const photoReference = tempUrl.split('1s')[1].split('&')[0];
+    //       if (photoReference) {
+    //         // Places Photo API URL 직접 구성
+    //         photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=${photoReference}&key=${apiKey}`;
+    //         console.log('Final photo URL:', photoUrl);
+    //       }
+    //     } catch (error) {
+    //       console.error('Error getting photo URL:', error);
+    //       photoUrl = logoRepeat;
+    //     }
+    //   }
+    // }
+
     if (places && places.length > 0) {
       name = places[0].name;
       placeId = places[0].place_id;
 
       if (places[0].photos && places[0].photos.length > 0) {
         try {
-          const tempUrl = places[0].photos[0].getUrl();
-          // URL에서 photo reference 추출
-          const photoReference = tempUrl.split('1s')[1].split('&')[0];
-          if (photoReference) {
-            // Places Photo API URL 직접 구성
-            photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=${photoReference}&key=${apiKey}`;
-            console.log('Final photo URL:', photoUrl);
+          // Google Maps JavaScript API의 Place Photo URL을 직접 구성
+          const photo = places[0].photos[0];
+          // 중요: 아래와 같이 rawReference 형식의 url 생성
+          const rawReference = photo
+            .getUrl({ maxWidth: 800, maxHeight: 800 })
+            .split('1s')[1]
+            .split('&')[0];
+
+          if (rawReference) {
+            // Places Photo API URL 형식으로 변경
+            photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=${rawReference}&key=${apiKey}`;
+            console.log('Final constructed photo URL:', photoUrl);
+          } else {
+            photoUrl = logoRepeat;
           }
         } catch (error) {
           console.error('Error getting photo URL:', error);
-          photoUrl = '/src/assets/logorepeat.png';
+          photoUrl = logoRepeat;
         }
       }
     }
 
     // 이미지가 없는 경우 기본 이미지 사용
     if (!photoUrl) {
-      photoUrl = '/src/assets/logorepeat.png';
+      photoUrl = logoRepeat;
     }
 
     return {
@@ -94,7 +124,7 @@ export const getPlaceDetails = async (
     console.error('Error fetching place details:', error);
     return {
       address: '',
-      photoUrl: '/src/assets/logorepeat.png',
+      photoUrl: logoRepeat,
       name: undefined,
       placeId: undefined,
     };


### PR DESCRIPTION
# feat(#63 ): 이미지 로드 실패 버그 수정

## 🔘Part
- [x] FE
 
## 🔎 작업 내용
### 1. 정적 이미지 import 방식 수정
- `/src/assets/` 경로를 사용하는 정적 이미지들의 로드 방식을 import 방식으로 변경
- 배포 환경에서도 안정적으로 이미지가 로드되도록 수정
- 영향 받은 컴포넌트: Search, BackButton, LeftContainer, MapContainer, LocationDetail

### 2. Google Places API 이미지 URL 처리 로직 개선
- Places API의 PhotoService.GetPhoto URL을 Places Photo API URL로 변환하는 로직 구현
- photo reference를 추출하여 직접 접근 가능한 URL 형식으로 변환
- 이미지 로드 실패 시 기본 이미지(logorepeat.png) 표시 로직 추가

## 🔧 앞으로의 과제
- Google Places API 응답 캐싱 전략 수립
- 이미지 로드 상태에 따른 로딩 UI/UX 개선

## ➕ 이슈 링크
- [otaku-map #63 ]

### 주요 변경사항
```typescript
// 정적 이미지 import 방식
import searchIcon from '../../assets/search.png';
<img src={searchIcon} alt="Search" />

// Google Places API 이미지 URL 처리
const photo = places[0].photos[0];
const rawReference = photo.getUrl({maxWidth: 800, maxHeight: 800})
 .split('1s')[1]
 .split('&')[0];
photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=${rawReference}&key=${apiKey}`;
```
