### PR TITLE
🐛 Fix: LocationDetail 이미지 로딩 방식 변경

### DIFF
--- a/src/components/map/LocationDetail.tsx
+++ b/src/components/map/LocationDetail.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import * as S from '../../styles/map/LocationDetail.styles';
-import { LocationDetail as LocationDetailType } from '../../types/map/route';
+import { LocationDetail as LocationDetailType, HashTag } from '../../types/map/route';
 import { useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
-import { PlaceDetails, getPlaceDetails } from '../../utils/mapUtils';
+import { PlaceDetails } from '../../utils/mapUtils';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/hooks/reduxHooks';
 import { openLoginModal } from '@/store/slices/modalSlice';
@@ -20,7 +20,7 @@ interface LocationDetailProps {
   placeLikeId?: number;
 }
 
-const DEFAULT_IMAGE = logoRepeat;
+// const DEFAULT_IMAGE = logoRepeat;
 
 const LocationDetail: React.FC<LocationDetailProps> = ({
   location,
@@ -40,6 +40,9 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
 
   // placeLikeDetail hook 사용
   const { placeLikeDetail, isLoading, error, fetchPlaceLikeDetail } = usePlaceLikeDetail();
+
+  const tags = placeLikeDetail?.hashtags || currentPlace.hashtags;
+  const MAX_TAGS = 3; // 최대 3개 태그만 표시
 
   // placeLikeId가 있을 경우 상세 정보 조회
   useEffect(() => {
@@ -108,6 +111,26 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
     return <S.Container>Error: {error.message}</S.Container>;
   }
 
+  // tags 처리 로직 수정
+  const getTags = () => {
+    if (placeLikeDetail?.hashtags) {
+      return placeLikeDetail.hashtags;
+    }
+    if (currentPlace.hashtags) {
+      return currentPlace.hashtags;
+    }
+    return [];
+  };
+
+  const renderTag = (tag: HashTag | string, index: number) => {
+    const tagName = typeof tag === 'string' ? tag : tag.name;
+    return (
+      <S.Tag key={index} data-full-text={`#${tagName}`}>
+        #{tagName}
+      </S.Tag>
+    );
+  };
+
   return (
     <S.Container>
       {onClose && (
@@ -139,9 +162,9 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
       </S.Subtitle>
       <S.Address>{placeDetails?.address || currentPlace.address}</S.Address>
       <S.TagContainer>
-        {(placeLikeDetail?.hashtags || currentPlace.hashtags).map((tag, index) => (
-          <S.Tag key={index}>#{typeof tag === 'string' ? tag : tag.name}</S.Tag>
-        ))}
+        {getTags()
+          .slice(0, MAX_TAGS)
+          .map((tag, index) => renderTag(tag, index))}
       </S.TagContainer>
 
       <S.FavButton onClick={handleFavClick}>

--- a/src/components/map/LocationDetail.tsx
+++ b/src/components/map/LocationDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import * as S from '../../styles/map/LocationDetail.styles';
 import { LocationDetail as LocationDetailType, HashTag } from '../../types/map/route';
 import { useNavigate } from 'react-router-dom';
@@ -13,14 +13,29 @@ import logoRepeat from '../../assets/logorepeat.png';
 import favIcon from '../../assets/fav.png';
 import favActiveIcon from '../../assets/fav2.png';
 
+const Tag: React.FC<{ tagName: string }> = ({ tagName }) => {
+  const tagRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (tagRef.current) {
+      const isOverflowed = tagRef.current.scrollWidth > tagRef.current.clientWidth;
+      tagRef.current.setAttribute('data-overflow', String(isOverflowed));
+    }
+  }, [tagName]);
+
+  return (
+    <S.Tag ref={tagRef} data-full-text={`#${tagName}`}>
+      #{tagName}
+    </S.Tag>
+  );
+};
+
 interface LocationDetailProps {
   location: LocationDetailType;
   placeDetails?: PlaceDetails;
   onClose?: () => void;
   placeLikeId?: number;
 }
-
-// const DEFAULT_IMAGE = logoRepeat;
 
 const LocationDetail: React.FC<LocationDetailProps> = ({
   location,
@@ -29,27 +44,61 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
   placeLikeId,
 }) => {
   const navigate = useNavigate();
-  const allPlaces = [location, ...(location.relatedPlaces || [])];
   const dispatch = useDispatch();
   const { isLoggedIn } = useAppSelector((state) => state.auth);
+  const { placeLikeDetail, isLoading, error, fetchPlaceLikeDetail } = usePlaceLikeDetail();
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isFavorited, setIsFavorited] = useState(false);
   const [imageLoadFailed, setImageLoadFailed] = useState(false);
-  const [placeDetailsData, setPlaceDetailsData] = useState<PlaceDetails | undefined>(placeDetails);
+
+  const titleRef = useRef<HTMLDivElement>(null);
+  const subtitleRef = useRef<HTMLDivElement>(null);
+  const addressRef = useRef<HTMLDivElement>(null);
+
+  const MAX_TAGS = 3;
+  const allPlaces = [location, ...(location.relatedPlaces || [])];
   const currentPlace = allPlaces[currentIndex];
 
-  // placeLikeDetail hook 사용
-  const { placeLikeDetail, isLoading, error, fetchPlaceLikeDetail } = usePlaceLikeDetail();
+  const displayData = useMemo(
+    () => ({
+      name: placeLikeDetail?.placeName || placeDetails?.name || currentPlace.name || '',
+      animeName: placeLikeDetail?.animationName || currentPlace.animeName || '',
+      address: placeDetails?.address || currentPlace.address || '',
+      tags: placeLikeDetail?.hashtags || currentPlace.hashtags || [],
+    }),
+    [placeLikeDetail, placeDetails, currentPlace],
+  );
 
-  const tags = placeLikeDetail?.hashtags || currentPlace.hashtags;
-  const MAX_TAGS = 3; // 최대 3개 태그만 표시
+  const imageSource = useMemo(() => {
+    console.log('LocationDetail - Current placeDetails:', placeDetails);
+    console.log('LocationDetail - Photo URL:', placeDetails?.photoUrl);
 
-  // placeLikeId가 있을 경우 상세 정보 조회
-  useEffect(() => {
-    if (placeLikeId) {
-      fetchPlaceLikeDetail(placeLikeId);
+    if (imageLoadFailed) {
+      console.log('LocationDetail - Image load failed, using fallback image');
+      return logoRepeat;
     }
-  }, [placeLikeId]);
+    return placeDetails?.photoUrl || logoRepeat;
+  }, [placeDetails, imageLoadFailed]);
+
+  useEffect(() => {
+    // mounted 변수 제거하고 cleanup 함수만 사용
+    const loadPlaceDetail = async () => {
+      if (!placeLikeId) return;
+
+      try {
+        await fetchPlaceLikeDetail(placeLikeId);
+      } catch (error) {
+        console.error('Failed to fetch place detail:', error);
+      }
+    };
+
+    loadPlaceDetail();
+
+    return () => {
+      // cleanup 필요한 경우에만 작성
+    };
+  }, [placeLikeId, fetchPlaceLikeDetail]);
 
   useEffect(() => {
     if (placeLikeDetail) {
@@ -57,12 +106,30 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
     }
   }, [placeLikeDetail]);
 
+  useEffect(() => {
+    const checkOverflow = (element: HTMLDivElement | null): boolean => {
+      if (!element) return false;
+      if (element.classList.contains('address')) {
+        return element.scrollHeight > element.clientHeight;
+      }
+      return element.scrollWidth > element.clientWidth;
+    };
+
+    const elements = [{ ref: titleRef }, { ref: subtitleRef }, { ref: addressRef }];
+
+    elements.forEach(({ ref }) => {
+      if (ref.current) {
+        const isOverflowed = checkOverflow(ref.current);
+        ref.current.setAttribute('data-overflow', String(isOverflowed));
+      }
+    });
+  }, [displayData]);
+
   const handleNextLocation = () => {
     setCurrentIndex((prev) => (prev === allPlaces.length - 1 ? 0 : prev + 1));
   };
 
   const handleReviewClick = () => {
-    // placeLikeDetail이 있으면 placeLikeId를, 없으면 location의 id를 사용
     const placeId = placeLikeDetail?.placeLikeId || location.id;
     navigate(`/places/${placeId}/review`);
   };
@@ -72,99 +139,55 @@ const LocationDetail: React.FC<LocationDetailProps> = ({
       dispatch(openLoginModal());
       return;
     }
-
-    // 로그인된 상태일 때만 좋아요 기능 실행
     setIsFavorited(!isFavorited);
   };
 
-  const imageSource = useMemo(() => {
-    console.log('PlaceDetails in LocationDetail:', placeDetails);
-    console.log('Current photoUrl:', placeDetails?.photoUrl);
-
-    // 1. 이미지 로드 실패한 경우
-    if (imageLoadFailed) {
-      console.log('Image load failed, using default');
-      return logoRepeat;
-    }
-
-    // 2. placeDetails가 있고 photoUrl이 있는 경우
-    if (placeDetails?.photoUrl) {
-      console.log('Using placeDetails photoUrl');
-      return placeDetails.photoUrl;
-    }
-
-    console.log('No valid photo URL found, using default');
-    // 3. 그 외의 경우 기본 이미지 사용
-    return logoRepeat;
-  }, [placeDetails?.photoUrl, imageLoadFailed]);
-
   const handleImageError = useCallback(() => {
-    console.log('Image load failed, switching to default image');
+    console.log('LocationDetail - Image failed to load:', placeDetails?.photoUrl);
     setImageLoadFailed(true);
-  }, []);
+  }, [placeDetails?.photoUrl]);
 
-  if (isLoading) {
-    return <S.Container>Loading...</S.Container>;
-  }
-
-  if (error) {
-    return <S.Container>Error: {error.message}</S.Container>;
-  }
-
-  // tags 처리 로직 수정
-  const getTags = () => {
-    if (placeLikeDetail?.hashtags) {
-      return placeLikeDetail.hashtags;
-    }
-    if (currentPlace.hashtags) {
-      return currentPlace.hashtags;
-    }
-    return [];
-  };
-
-  const renderTag = (tag: HashTag | string, index: number) => {
-    const tagName = typeof tag === 'string' ? tag : tag.name;
-    return (
-      <S.Tag key={index} data-full-text={`#${tagName}`}>
-        #{tagName}
-      </S.Tag>
-    );
-  };
+  if (isLoading) return <S.Container>Loading...</S.Container>;
+  if (error) return <S.Container>Error: {error.message}</S.Container>;
 
   return (
     <S.Container>
       {onClose && (
         <S.CloseButton onClick={onClose}>
-          <X
-            size={20}
-            color="#FFFFFF"
-            style={{ width: '20px', height: '20px' }}
-            absoluteStrokeWidth
-          />
+          <X size={20} color="#FFFFFF" absoluteStrokeWidth />
         </S.CloseButton>
       )}
+
       <S.LocationImage
         src={imageSource}
-        alt={placeLikeDetail ? placeLikeDetail.placeName : currentPlace.name}
+        alt={displayData.name}
         onError={handleImageError}
         key={imageSource}
       />
+
       {allPlaces.length > 1 && (
         <S.PaginationButton onClick={handleNextLocation}>
           <img src={nextIcon} alt="next" />
         </S.PaginationButton>
       )}
-      <S.Title>
-        {placeLikeDetail ? placeLikeDetail.placeName : placeDetails?.name || currentPlace.name}
+
+      <S.Title ref={titleRef} title={displayData.name}>
+        {displayData.name}
       </S.Title>
-      <S.Subtitle>
-        {placeLikeDetail ? placeLikeDetail.animationName : currentPlace.animeName}
+
+      <S.Subtitle ref={subtitleRef} title={displayData.animeName}>
+        {displayData.animeName}
       </S.Subtitle>
-      <S.Address>{placeDetails?.address || currentPlace.address}</S.Address>
+
+      <S.Address ref={addressRef} title={displayData.address} className="address">
+        {displayData.address}
+      </S.Address>
+
       <S.TagContainer>
-        {getTags()
-          .slice(0, MAX_TAGS)
-          .map((tag, index) => renderTag(tag, index))}
+        {displayData.tags.slice(0, MAX_TAGS).map((tag, index) => {
+          const tagName = typeof tag === 'string' ? tag : tag.name;
+          return <Tag key={index} tagName={tagName} />;
+        })}
       </S.TagContainer>
 
       <S.FavButton onClick={handleFavClick}>

--- a/src/components/map/RouteDescriptionEditor.tsx
+++ b/src/components/map/RouteDescriptionEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import * as S from '../../styles/map/RouteDescriptionEditor.styles';
 import { toast } from 'react-toastify';
 
@@ -7,8 +7,24 @@ interface RouteDescriptionEditorProps {
   onSave: (description: string) => void;
 }
 
+const MAX_LENGTH = 25;
+
 const RouteDescriptionEditor = ({ description, onSave }: RouteDescriptionEditorProps) => {
   const [currentDescription, setCurrentDescription] = useState(description);
+  const [charCount, setCharCount] = useState(description.length);
+
+  useEffect(() => {
+    setCharCount(currentDescription.length);
+  }, [currentDescription]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    if (newValue.length <= MAX_LENGTH) {
+      setCurrentDescription(newValue);
+    } else {
+      toast.warning('최대 25자까지 입력 가능합니다.');
+    }
+  };
 
   const handleSave = () => {
     if (!currentDescription.trim()) {
@@ -23,10 +39,12 @@ const RouteDescriptionEditor = ({ description, onSave }: RouteDescriptionEditorP
     <S.Container>
       <S.InputArea>
         <S.TextArea
-          placeholder="루트명을 입력하세요"
+          placeholder="루트명을 입력하세요 (최대 25자)"
           value={currentDescription}
-          onChange={(e) => setCurrentDescription(e.target.value)}
+          onChange={handleChange}
+          maxLength={MAX_LENGTH}
         />
+        <S.CharCount>{`${charCount}/${MAX_LENGTH}`}</S.CharCount>
       </S.InputArea>
       <S.DashedLine top={42} />
       <S.DashedLine top={84} />

--- a/src/hooks/map/usePlaceLikeDetail.ts
+++ b/src/hooks/map/usePlaceLikeDetail.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+// usePlaceLikeDetail.ts
+import { useState, useCallback } from 'react';
 import { PlaceLikeDetail } from '@/types/map/placeLikeDetail';
 import { getPlaceLikeDetail } from '@/api/map/placeLikeDetail';
 
@@ -7,23 +8,23 @@ export const usePlaceLikeDetail = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetchPlaceLikeDetail = async (placeLikeId: number) => {
+  const fetchPlaceLikeDetail = useCallback(async (placeLikeId: number) => {
     try {
       setIsLoading(true);
       setError(null);
       const response = await getPlaceLikeDetail(placeLikeId);
 
-      if (response.isSuccess) {
+      if (response.isSuccess && response.result) {
         setPlaceLikeDetail(response.result);
       } else {
-        throw new Error(response.message);
+        throw new Error(response.message || '데이터를 불러오는데 실패했습니다.');
       }
     } catch (err) {
       setError(err as Error);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []); // 의존성 배열을 비워서 함수가 다시 생성되지 않도록 함
 
   return {
     placeLikeDetail,

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -59,30 +59,38 @@ const MapPage = () => {
     fetchDetails();
   }, [selectedPlaceLikeId]);
 
+  // MapPage.tsx의 useEffect 부분 수정
   useEffect(() => {
     const fetchDetails = async () => {
-      if (!window.google?.maps || !mapInstance.current) return;
+      if (!window.google?.maps || !mapInstance.current) {
+        console.log('MapPage - Google Maps not initialized');
+        return;
+      }
 
       try {
         if (placeLikeDetail) {
+          console.log('MapPage - Fetching details for placeLikeDetail:', placeLikeDetail);
           const details = await getPlaceDetails(
             placeLikeDetail.lat,
             placeLikeDetail.lng,
             import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
             mapInstance.current,
           );
+          console.log('MapPage - Fetched place details:', details);
           setPlaceDetails(details);
         } else if (selectedPlace) {
+          console.log('MapPage - Fetching details for selectedPlace:', selectedPlace);
           const details = await getPlaceDetails(
             selectedPlace.latitude,
             selectedPlace.longitude,
             import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
             mapInstance.current,
           );
+          console.log('MapPage - Fetched place details:', details);
           setPlaceDetails(details);
         }
       } catch (error) {
-        console.error('Failed to fetch place details:', error);
+        console.error('MapPage - Failed to fetch place details:', error);
       }
     };
 
@@ -205,7 +213,10 @@ const MapPage = () => {
           zoom={selectedPlace || placeLikeDetail ? 17 : 16}
           locations={mapLocations}
           selectedLocation={mapLocations[0] || null}
-          onMarkerClick={() => setShowLocationDetail(true)}
+          onMarkerClick={(location, details) => {
+            setPlaceDetails(details);
+            setShowLocationDetail(true);
+          }}
         />
         <FilterButton onFilterChange={handleFilterChange} />
         {showLocationDetail && (

--- a/src/pages/map/RoutePage.tsx
+++ b/src/pages/map/RoutePage.tsx
@@ -51,7 +51,8 @@ const sampleLocations: RouteLocation[] = [
     isSelected: false,
     latitude: 35.6962,
     longitude: 139.5704,
-    animeName: '지브리 작품들',
+    animeName:
+      '마루 밑 아리에티, 토토로, 포뇨, 하울의 움직이는 성, 마녀배달부 키키zmzmzmzdkdkdkdkdkdkdkdkfjlakjfldf아ㅓㅁ니ㅏ러이ㅏㅓ라민m',
     hashtags: ['지브리', '미야자키하야오', '토토로'],
   },
   {

--- a/src/styles/map/LeftContainer.styles.ts
+++ b/src/styles/map/LeftContainer.styles.ts
@@ -170,37 +170,49 @@ export const RecommendationsContainer = styled.div`
 
 export const RecommendationItem = styled.div<RecommendationItemProps>`
   box-sizing: border-box;
-  width: 237px; // 296 * 0.8
-  min-height: 25px; // 31 * 0.8
+  width: 237px;
+  min-height: 25px;
   border: 1px solid #d1c1ff;
-  border-radius: 16px; // 20 * 0.8
-  padding: 8px 16px; // 수정: 상하 패딩 증가
+  border-radius: 16px;
+  padding: 8px 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   transition: all 0.2s;
-  position: relative; // 툴팁을 위한 position 설정
+  position: relative;
 
   &:hover {
     background-color: rgba(209, 193, 255, 0.1);
   }
 
-  // 호버 시 전체 텍스트를 보여주는 툴팁
-  &:hover::after {
+  &[data-show-tooltip='true']:hover::after {
     content: attr(data-full-text);
-    position: absolute;
+    position: fixed;
     left: 50%;
     transform: translateX(-50%);
-    top: -40px;
-    background: rgba(37, 38, 96, 0.9);
-    padding: 8px 12px;
-    border-radius: 8px;
-    font-size: 12px;
-    white-space: nowrap;
+    top: auto;
+    bottom: 100%;
+    margin-bottom: 8px;
+    background: rgba(37, 38, 96, 0.95);
     color: white;
-    z-index: 1000;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 14px;
+    white-space: normal;
+    max-width: 300px;
+    z-index: 1001;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      opacity 0.2s,
+      visibility 0.2s;
+    pointer-events: none;
+  }
+
+  &[data-show-tooltip='true']:hover::after {
+    opacity: 1;
+    visibility: visible;
   }
 `;
 
@@ -212,13 +224,11 @@ export const RecommendationText = styled.span`
   line-height: 16px;
   color: #ffffff;
   text-align: center;
-
-  // 2줄까지 표시하고 말줄임표 처리
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-all;
-  max-height: 32px; // line-height * 2
+  max-height: 32px;
 `;

--- a/src/styles/map/LocationDetail.styles.ts
+++ b/src/styles/map/LocationDetail.styles.ts
@@ -110,16 +110,21 @@ export const TagContainer = styled.div`
   bottom: 22px; // 24 * 0.9
   display: flex;
   gap: 7px; // 8 * 0.9
+  max-width: 276px; // (78px * 3) + (7px * 2) = 최대 3개 태그 + 간격
+  overflow: hidden; // 넘치는 태그 숨김
 `;
 
 export const Tag = styled.div`
-  width: 78px; // 87 * 0.9
+  min-width: 78px; // 87 * 0.9
+  max-width: 87px; // 최대 너비 제한
   height: 23px; // 26 * 0.9
+  padding: 0 12px;
   background: #bdaee5;
   border-radius: 23px; // 25 * 0.9
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
 
   font-family: 'Gothic A1';
   font-style: normal;
@@ -127,6 +132,27 @@ export const Tag = styled.div`
   font-size: 11px; // 12 * 0.9
   line-height: 14px; // 15 * 0.9
   color: #000000;
+
+  // 긴 텍스트 처리
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  // 호버 시 툴팁
+  &:hover::after {
+    content: attr(data-full-text);
+    position: absolute;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(37, 38, 96, 0.9);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    white-space: nowrap;
+    z-index: 1000;
+  }
 `;
 
 export const FavButton = styled.button`

--- a/src/styles/map/LocationDetail.styles.ts
+++ b/src/styles/map/LocationDetail.styles.ts
@@ -2,23 +2,29 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   position: absolute;
-  width: 628px; // 698 * 0.9
-  height: 202px; // 224 * 0.9
+  width: 628px;
+  height: 202px;
   left: 50%;
-  bottom: 36px; // 40 * 0.9
+  bottom: 36px;
   transform: translateX(-50%);
   background: #252660;
-  box-shadow: 0px 9px 7px 3px rgba(0, 0, 0, 0.25); // 10 * 0.9, 8 * 0.9
-  border-radius: 23px; // 25 * 0.9
+  box-shadow: 0px 9px 7px 3px rgba(0, 0, 0, 0.25);
+  border-radius: 23px;
   z-index: 1000;
+
+  @media (max-width: 768px) {
+    width: calc(100% - 32px);
+    min-height: 202px;
+    height: auto;
+  }
 `;
 
 export const PaginationButton = styled.button`
   position: absolute;
-  top: 81px; // 90 * 0.9
-  right: 12px; // 13 * 0.9
-  width: 25px; // 28 * 0.9
-  height: 16px; // 18 * 0.9
+  top: 81px;
+  right: 12px;
+  width: 25px;
+  height: 16px;
   background: transparent;
   border: none;
   border-radius: 50%;
@@ -28,6 +34,7 @@ export const PaginationButton = styled.button`
   justify-content: center;
   z-index: 1001;
   padding: 0;
+  transition: transform 0.2s ease;
 
   img {
     width: 100%;
@@ -42,125 +49,275 @@ export const PaginationButton = styled.button`
   &:focus {
     outline: none;
   }
-`;
 
-export const LocationImageWrapper = styled.div`
-  position: relative;
-  width: 143px; // 159 * 0.9
-  height: 158px; // 175 * 0.9
-  left: 25px; // 28 * 0.9
-  top: 22px; // 24 * 0.9
-  overflow: hidden;
-  border-radius: 7px; // 8 * 0.9
+  @media (max-width: 768px) {
+    top: 50%;
+    transform: translateY(-50%);
+    right: 8px;
+  }
 `;
 
 export const LocationImage = styled.img`
   position: absolute;
-  width: 143px; // 159 * 0.9
-  height: 158px; // 175 * 0.9
-  left: 25px; // 28 * 0.9
-  top: 22px; // 24 * 0.9
+  width: 143px;
+  height: 158px;
+  left: 25px;
+  top: 22px;
   object-fit: cover;
-  border-radius: 7px; // 8 * 0.9
+  border-radius: 7px;
+
+  @media (max-width: 768px) {
+    position: relative;
+    left: 16px;
+    top: 16px;
+    width: 120px;
+    height: 120px;
+  }
 `;
 
-export const Title = styled.h1`
-  position: absolute;
-  left: 188px; // 209 * 0.9
-  top: 15px; // 17 * 0.9
+const BaseText = styled.div`
+  position: relative;
   font-family: 'Gothic A1';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 27px; // 30 * 0.9
-  line-height: 34px; // 38 * 0.9
   color: #ffffff;
   margin: 0;
 `;
 
-export const Subtitle = styled.h2`
+export const Title = styled(BaseText)`
   position: absolute;
-  left: 188px; // 209 * 0.9
-  top: 50px; // 56 * 0.9
-  font-family: 'Gothic A1';
-  font-style: normal;
+  left: 188px;
+  top: 15px;
   font-weight: 600;
-  font-size: 27px; // 30 * 0.9
-  line-height: 34px; // 38 * 0.9
-  color: #ffffff;
-  margin: 0;
+  font-size: 27px;
+  line-height: 34px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 380px;
+
+  &[data-overflow='true'] {
+    position: relative;
+
+    &::after {
+      content: attr(title);
+      position: fixed; // absolute 대신 fixed 사용
+      left: 50%;
+      transform: translateX(-50%);
+      top: auto;
+      bottom: 100%;
+      margin-bottom: 8px;
+      background: rgba(37, 38, 96, 0.95);
+      color: white;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      white-space: normal;
+      max-width: 300px;
+      z-index: 1001;
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        opacity 0.2s,
+        visibility 0.2s;
+      pointer-events: none;
+    }
+
+    &:hover::after {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  @media (max-width: 768px) {
+    position: relative;
+    left: 16px;
+    top: 24px;
+    max-width: calc(100% - 32px);
+  }
 `;
 
-export const Address = styled.p`
+export const Subtitle = styled(BaseText)`
   position: absolute;
-  left: 188px; // 209 * 0.9
-  top: 85px; // 94 * 0.9
-  font-family: 'Gothic A1';
-  font-style: normal;
+  left: 188px;
+  top: 50px;
+  font-weight: 600;
+  font-size: 27px;
+  line-height: 34px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 380px;
+
+  &[data-overflow='true'] {
+    position: relative;
+
+    &::after {
+      content: attr(title);
+      position: fixed;
+      left: 50%;
+      transform: translateX(-50%);
+      top: auto;
+      bottom: 100%;
+      margin-bottom: 8px;
+      background: rgba(37, 38, 96, 0.95);
+      color: white;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      white-space: normal;
+      max-width: 300px;
+      z-index: 1001;
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        opacity 0.2s,
+        visibility 0.2s;
+      pointer-events: none;
+    }
+
+    &:hover::after {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  @media (max-width: 768px) {
+    position: relative;
+    left: 16px;
+    top: 32px;
+    max-width: calc(100% - 32px);
+  }
+`;
+
+export const Address = styled(BaseText)`
+  position: absolute;
+  left: 188px;
+  top: 85px;
   font-weight: 400;
-  font-size: 18px; // 20 * 0.9
-  line-height: 27px; // 30 * 0.9
-  color: #ffffff;
-  margin: 0;
-  max-width: 405px; // 450 * 0.9
+  font-size: 18px;
+  line-height: 27px;
+  max-width: 405px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  &[data-overflow='true'] {
+    position: relative;
+
+    &::after {
+      content: attr(title);
+      position: fixed;
+      left: 50%;
+      transform: translateX(-50%);
+      top: auto;
+      bottom: 100%;
+      margin-bottom: 8px;
+      background: rgba(37, 38, 96, 0.95);
+      color: white;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      white-space: normal;
+      max-width: 300px;
+      z-index: 1001;
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        opacity 0.2s,
+        visibility 0.2s;
+      pointer-events: none;
+    }
+
+    &:hover::after {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  @media (max-width: 768px) {
+    position: relative;
+    left: 16px;
+    top: 40px;
+    max-width: calc(100% - 32px);
+  }
 `;
 
 export const TagContainer = styled.div`
   position: absolute;
-  left: 184px; // 204 * 0.9
-  bottom: 22px; // 24 * 0.9
+  left: 184px;
+  bottom: 22px;
   display: flex;
-  gap: 7px; // 8 * 0.9
-  max-width: 276px; // (78px * 3) + (7px * 2) = 최대 3개 태그 + 간격
-  overflow: hidden; // 넘치는 태그 숨김
+  gap: 7px;
+  max-width: 276px;
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    position: relative;
+    left: 16px;
+    bottom: -48px;
+    max-width: calc(100% - 180px);
+  }
 `;
 
 export const Tag = styled.div`
-  min-width: 78px; // 87 * 0.9
-  max-width: 87px; // 최대 너비 제한
-  height: 23px; // 26 * 0.9
+  min-width: 78px;
+  max-width: 87px;
+  height: 23px;
   padding: 0 12px;
   background: #bdaee5;
-  border-radius: 23px; // 25 * 0.9
+  border-radius: 23px;
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-
   font-family: 'Gothic A1';
-  font-style: normal;
   font-weight: 600;
-  font-size: 11px; // 12 * 0.9
-  line-height: 14px; // 15 * 0.9
+  font-size: 11px;
+  line-height: 14px;
   color: #000000;
-
-  // 긴 텍스트 처리
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  // 호버 시 툴팁
-  &:hover::after {
-    content: attr(data-full-text);
-    position: absolute;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(37, 38, 96, 0.9);
-    color: white;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 10px;
-    white-space: nowrap;
-    z-index: 1000;
+  &[data-overflow='true'] {
+    position: relative;
+
+    &::after {
+      content: attr(data-full-text);
+      position: fixed;
+      left: 50%;
+      transform: translateX(-50%);
+      top: auto;
+      bottom: 100%;
+      margin-bottom: 8px;
+      background: rgba(37, 38, 96, 0.95);
+      color: white;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      white-space: nowrap;
+      z-index: 1001;
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        opacity 0.2s,
+        visibility 0.2s;
+      pointer-events: none;
+    }
+
+    &:hover::after {
+      opacity: 1;
+      visibility: visible;
+    }
   }
 `;
 
 export const FavButton = styled.button`
   position: absolute;
-  width: 28px; // 31 * 0.9
-  height: 25px; // 28 * 0.9
-  right: 144px; // 160 * 0.9
-  bottom: 22px; // 24 * 0.9
+  width: 28px;
+  height: 25px;
+  right: 144px;
+  bottom: 22px;
   background: transparent;
   border: none;
   cursor: pointer;
@@ -168,6 +325,7 @@ export const FavButton = styled.button`
   align-items: center;
   justify-content: center;
   padding: 0;
+  transition: transform 0.2s ease;
 
   img {
     width: 100%;
@@ -175,46 +333,57 @@ export const FavButton = styled.button`
     object-fit: contain;
   }
 
+  &:hover {
+    transform: scale(1.1);
+  }
+
   &:focus {
     outline: none;
-    box-shadow: none;
+  }
+
+  @media (max-width: 768px) {
+    right: 120px;
   }
 `;
 
 export const ReviewButton = styled.button`
   position: absolute;
-  width: 112px; // 124 * 0.9
-  height: 38px; // 42 * 0.9
-  right: 22px; // 24 * 0.9
-  bottom: 22px; // 24 * 0.9
+  width: 112px;
+  height: 38px;
+  right: 22px;
+  bottom: 22px;
   background: #fff5d5;
-  border-radius: 23px; // 25 * 0.9
+  border-radius: 23px;
   border: none;
   cursor: pointer;
-
   display: flex;
   align-items: center;
   justify-content: center;
-
   font-family: 'Gothic A1';
   font-style: normal;
   font-weight: 600;
-  font-size: 14px; // 16 * 0.9
-  line-height: 27px; // 30 * 0.9
+  font-size: 14px;
+  line-height: 27px;
   color: #101148;
+  transition: all 0.2s ease;
 
   &:hover {
     background: #ffe9b3;
+    transform: translateY(-1px);
+  }
+
+  @media (max-width: 768px) {
+    right: 16px;
   }
 `;
 
 export const CloseButton = styled.button`
   position: absolute;
-  top: 9px; // 10 * 0.9
-  right: 12px; // 13 * 0.9
+  top: 9px;
+  right: 12px;
   padding: 4px;
-  width: 25px; // 28 * 0.9
-  height: 25px; // 28 * 0.9
+  width: 25px;
+  height: 25px;
   border-radius: 50%;
   background: transparent;
   border: none;
@@ -224,22 +393,27 @@ export const CloseButton = styled.button`
   align-items: center;
   justify-content: center;
   z-index: 9999;
+  transition: transform 0.2s ease;
 
   svg {
-    min-width: 18px; // 20 * 0.9
-    min-height: 18px; // 20 * 0.9
-    width: 18px; // 20 * 0.9
-    height: 18px; // 20 * 0.9
+    min-width: 18px;
+    min-height: 18px;
+    width: 18px;
+    height: 18px;
     color: #ffffff;
     stroke: currentColor;
   }
 
   &:hover {
-    background: transparent;
+    transform: scale(1.1);
   }
 
   &:focus {
     outline: none;
-    box-shadow: none;
+  }
+
+  @media (max-width: 768px) {
+    top: 8px;
+    right: 8px;
   }
 `;

--- a/src/styles/map/RouteDescriptionEditor.styles.ts
+++ b/src/styles/map/RouteDescriptionEditor.styles.ts
@@ -78,3 +78,13 @@ export const EditButton = styled.button`
   cursor: pointer;
   z-index: 3;
 `;
+
+export const CharCount = styled.span`
+  position: absolute;
+  right: 0;
+  top: -20px;
+  font-family: 'Gothic A1';
+  font-size: 12px;
+  color: #999797;
+  z-index: 1;
+`;


### PR DESCRIPTION
# 🐛 Fix(#68 ): LocationDetail 이미지 로딩 방식 변경

## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- MapPage의 LocationDetail 이미지 로딩 로직을 RoutePage와 동일한 방식으로 변경
- 1. MapPage의 useEffect에서 placeDetails를 가져오는 로직 제거
2. MapContainer의 onMarkerClick에서 직접 placeDetails 전달하도록 수정:
```typescript
<MapContainer
  // ...other props
  onMarkerClick={(location, details) => {
    setPlaceDetails(details);
    setShowLocationDetail(true);
  }}
/>
```

  <br/>

## 🔧 앞으로의 과제
- 루트 상세보기 api 연동

  <br/>

## ➕ 이슈 링크

- [OtakuWeb #68 ]

<br/>
