### PR TITLE
fix: 로그인 시 진행중인 이벤트 좋아요 반영 여부

### DIFF
--- a/src/hooks/main/usePopularEvents.ts
+++ b/src/hooks/main/usePopularEvents.ts
@@ -1,10 +1,13 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getPopularEvents, toggleEventLike } from '@/api/main/event';
 import { Event } from '@/types/main/event';
+import { useAppSelector } from '@/hooks/reduxHooks';
 
 export const usePopularEvents = () => {
+  const { isLoggedIn } = useAppSelector((state) => state.auth);
+
   return useQuery<Event[]>({
-    queryKey: ['popularEvents'],
+    queryKey: ['popularEvents', isLoggedIn], // isLoggedIn을 queryKey에 추가
     queryFn: async () => {
       const response = await getPopularEvents();
       if (response.isSuccess && Array.isArray(response.result)) {
@@ -19,22 +22,3 @@ export const usePopularEvents = () => {
     retryDelay: 1000,
   });
 };
-
-// export const useEventLikeToggle = () => {
-//   const queryClient = useQueryClient();
-
-//   return useMutation({
-//     mutationFn: toggleEventLike,
-//     onSuccess: (data, eventId) => {
-//       // Update the cache optimistically
-//       queryClient.setQueryData<Event[]>(['popularEvents'], (oldData) => {
-//         if (!oldData) return oldData;
-//         return oldData.map(event =>
-//           event.id === eventId
-//             ? { ...event, isLiked: data.result.isLiked }
-//             : event
-//         );
-//       });
-//     },
-//   });
-// };


### PR DESCRIPTION
# 🔍 관련 이슈
- Fixes #49 

# 📝 변경 사항
- 로그인 후 EventCard의 좋아요 상태가 즉시 반영되도록 수정
- usePopularEvents 훅의 queryKey에 isLoggedIn 상태 추가

# 🔍 변경 상세 내용
## 기존 동작
- 로그인 후 좋아요 상태를 확인하기 위해 페이지 새로고침이 필요했음
- 사용자 경험이 저하되는 문제가 있었음

## 개선된 동작
- 로그인 상태 변경 시 자동으로 이벤트 데이터를 다시 불러옴
- 새로고침 없이 즉시 좋아요 상태가 반영됨
