### PR TITLE
feat: 이벤트 상세 페이지 이동 , 애니메이션에 따른 후기 및 태그 변경, 유료 무료 api 추가

### DIFF
--- a/src/api/event/short-review.ts
+++ b/src/api/event/short-review.ts
@@ -7,6 +7,7 @@ import {
   UpdateShortReviewRequest,
   DeleteShortReviewResponse,
   UpdateShortReviewResponse,
+  ShortReviewReactionResponse,
 } from '@/types/event/short-review';
 
 export const createShortReview = async (
@@ -69,6 +70,22 @@ export const deleteShortReview = async (
     return response.data;
   } catch (err) {
     console.error('Error deleting short review:', err);
+    throw err;
+  }
+};
+
+export const toggleShortReviewReaction = async (
+  reviewId: number,
+  reactionType: 0 | 1,
+): Promise<ShortReviewReactionResponse> => {
+  try {
+    const response = await instance.post<ShortReviewReactionResponse>(
+      `/events/short-reviews/${reviewId}/reaction`,
+      reactionType,
+    );
+    return response.data;
+  } catch (err) {
+    console.error('Error toggling short review reaction:', err);
     throw err;
   }
 };

--- a/src/api/event/short-review.ts
+++ b/src/api/event/short-review.ts
@@ -16,7 +16,7 @@ export const createShortReview = async (
 ): Promise<ShortReviewResponse> => {
   try {
     const response = await instance.post<ShortReviewResponse>(
-      `/events/${eventId}/short-reviews`,
+      `/api/events/${eventId}/short-reviews`,
       reviewData,
     );
     return response.data;
@@ -32,7 +32,7 @@ export const getEventShortReviews = async (
 ): Promise<EventShortReviewListResponse> => {
   try {
     const response = await instance.get<EventShortReviewListResponse>(
-      `/events/${eventId}/short-reviews`,
+      `/api/events/${eventId}/short-reviews`,
       {
         params: { page },
       },
@@ -50,7 +50,7 @@ export const updateShortReview = async (
 ): Promise<UpdateShortReviewResponse> => {
   try {
     const response = await instance.patch<UpdateShortReviewResponse>(
-      `/events/short-reviews/${eventShortReviewId}`,
+      `/api/events/short-reviews/${eventShortReviewId}`,
       data,
     );
     return response.data;
@@ -65,7 +65,7 @@ export const deleteShortReview = async (
 ): Promise<DeleteShortReviewResponse> => {
   try {
     const response = await instance.delete<DeleteShortReviewResponse>(
-      `/events/short-reviews/${eventShortReviewId}`,
+      `/api/events/short-reviews/${eventShortReviewId}`,
     );
     return response.data;
   } catch (err) {
@@ -80,8 +80,8 @@ export const toggleShortReviewReaction = async (
 ): Promise<ShortReviewReactionResponse> => {
   try {
     const response = await instance.post<ShortReviewReactionResponse>(
-      `/events/short-reviews/${reviewId}/reaction`,
-      reactionType,
+      `/api/events/short-reviews/${reviewId}/reaction`,
+      { reactionType },
     );
     return response.data;
   } catch (err) {

--- a/src/api/review/point.ts
+++ b/src/api/review/point.ts
@@ -1,0 +1,10 @@
+// api/review/point.ts
+
+import instance from '@/api/axios';
+import { PointBalanceResponse } from '@/types/review/point';
+
+export const getPointBalance = () => {
+  return instance
+    .get<PointBalanceResponse>('/api/points/balance')
+    .then((response) => response.data);
+};

--- a/src/pages/EventPage2.tsx
+++ b/src/pages/EventPage2.tsx
@@ -176,23 +176,29 @@ const EventPage = () => {
       const response = await originalHandleReviewSubmit();
 
       // 리뷰 제출 성공 시
-      if (response && response.isSuccess) {
-        // 새로 등록된 리뷰 객체 생성 (타입 단언 사용)
+      if (response && response.isSuccess && response.result) {
         const newReview: EventShortReview = {
-          id: response.result.id,
-          content: reviewText,
-          rating: inputRating,
-          username: userProfile?.nickname || '',
+          id: response.result.reviewId,
+          content: response.result.content,
+          rating: response.result.rating,
+          user: {
+            userId: 0, // 임시 값
+            nickname: userProfile?.nickname || '',
+            profileImage: userProfile?.profileImageUrl || '',
+          },
           profileImage: {
+            id: 0,
+            uuid: '',
+            fileName: '',
             fileUrl: userProfile?.profileImageUrl || '',
           },
           likes: 0,
           dislikes: 0,
           userVote: null,
-        } as EventShortReview;
+        };
 
         // 기존 리뷰 목록 앞에 새 리뷰 추가
-        setShortReviews((prevReviews: EventShortReview[]) => [newReview, ...prevReviews]);
+        setShortReviews((prevReviews) => [newReview, ...prevReviews]);
 
         // 입력 필드 초기화
         setReviewText('');
@@ -422,12 +428,12 @@ const EventPage = () => {
               {paginatedShortReviews.map((review) => (
                 <S.ReviewCard
                   key={review.id}
-                  $isMyReview={review.username === userProfile?.nickname} // $isMyReview prop은 필수이므로 기본값 제공
+                  $isMyReview={review.user.nickname === userProfile?.nickname}
                 >
                   <S.ReviewHeader>
                     <S.Avatar src={review.profileImage.fileUrl} alt="프로필" />
                     <S.UserInfo>
-                      <S.UserName>{review.id}</S.UserName>
+                      <S.UserName>{review.user.nickname}</S.UserName>
                       {editingId === review.id ? (
                         <S.StarRatingInput>
                           {[1, 2, 3, 4].map((star) => (
@@ -468,7 +474,7 @@ const EventPage = () => {
                     <S.ReviewContent>{review.content}</S.ReviewContent>
                   )}
 
-                  {review.username === userProfile?.nickname && (
+                  {review.user.nickname === userProfile?.nickname && (
                     <S.EditDeleteButtons>
                       {editingId === review.id ? (
                         <>

--- a/src/pages/EventPage2.tsx
+++ b/src/pages/EventPage2.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import { ThumbsUp, ThumbsDown, ExternalLink } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import MapContainer from '@/components/map/MapContainer';
 import { saveEvent } from '@/api/event/SaveEvent';
@@ -146,6 +146,13 @@ const EventPage = () => {
     (currentPage - 1) * REVIEWS_PER_PAGE,
     currentPage * REVIEWS_PER_PAGE,
   );
+
+  // Handle opening the official site
+  const handleOpenOfficialSite = () => {
+    if (eventDetails && eventDetails.site) {
+      window.open(eventDetails.site, '_blank', 'noopener,noreferrer');
+    }
+  };
 
   const handleTextAreaClick = (e: React.MouseEvent) => {
     if (!isLoggedIn) {
@@ -296,8 +303,21 @@ const EventPage = () => {
         <S.TabWrapper>
           <S.TabInner>
             {['기본정보', '후기', '공식 사이트'].map((tab) => (
-              <S.Tab key={tab} isActive={activeTab === tab} onClick={() => setActiveTab(tab)}>
+              <S.Tab
+                key={tab}
+                isActive={activeTab === tab}
+                onClick={() => {
+                  if (tab === '공식 사이트') {
+                    handleOpenOfficialSite();
+                  } else {
+                    setActiveTab(tab);
+                  }
+                }}
+              >
                 {tab}
+                {tab === '공식 사이트' && eventDetails?.site && (
+                  <ExternalLink size={16} style={{ marginLeft: '5px' }} color="#0c004b" />
+                )}
               </S.Tab>
             ))}
           </S.TabInner>

--- a/src/pages/ReviewPage1.tsx
+++ b/src/pages/ReviewPage1.tsx
@@ -3,7 +3,6 @@ import { FaSearch } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import sectionImage from '../assets/1.png';
 import deleteIcon from '../assets/X.png';
-import conanImage from '../assets/conan.png';
 import * as S from '../styles/review/ReviewPage.style';
 import { useTopReviews } from '../hooks/main/useTopReviews';
 import { useRecentSearches } from '../hooks/review/useRecentSearch';
@@ -92,9 +91,9 @@ const ReviewPage1: React.FC = () => {
         {isSearching && <S.LoadingText>검색 중...</S.LoadingText>}
 
         {/* 검색어가 없을 때 가이드 메시지 */}
-        {!searchInput.trim() && !searchError && !isSearching && (
+        {/* {!searchInput.trim() && !searchError && !isSearching && (
           <S.NoResults>관심있는 여행 후기를 검색해보세요!</S.NoResults>
-        )}
+        )} */}
 
         <S.RecentSearch>
           <S.Title>최근검색어</S.Title>

--- a/src/pages/ReviewPage3.tsx
+++ b/src/pages/ReviewPage3.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { fetchReviews } from '../api/review/PlaceReview';
 import { fetchPlaceAnimations } from '../api/review/animation';
 import { searchAnimations, addAnimation } from '../api/review/AddAnimation';
-import { ReviewResponse, SortType, AnimationGroup } from '../types/review/PlaceReview';
+import { ReviewResponse, SortType, AnimationGroup, Review } from '../types/review/PlaceReview';
 import { PlaceAnimation } from '../types/review/animation';
 import { tokenStorage } from '@/utils/token';
 import { savePlace } from '../api/review/SavePlace';
@@ -16,6 +16,7 @@ const ReviewPage3 = () => {
 
   // Review-related states
   const [reviewData, setReviewData] = useState<ReviewResponse['result'] | null>(null);
+  const [filteredReviews, setFilteredReviews] = useState<AnimationGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -31,6 +32,19 @@ const ReviewPage3 = () => {
   const [searchResults, setSearchResults] = useState<{ animationId: number; name: string }[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [isCustomAnimationMode, setIsCustomAnimationMode] = useState(false);
+
+  // 애니메이션 선택에 따라 필터링된 리뷰 업데이트
+  useEffect(() => {
+    if (reviewData && selectedAnimation) {
+      const filtered = reviewData.animationGroups.filter(
+        (group) => group.animationId === selectedAnimation.animationId,
+      );
+      setFilteredReviews(filtered);
+    } else if (reviewData) {
+      // 애니메이션 선택 안 했을 때는 전체 리뷰
+      setFilteredReviews(reviewData.animationGroups);
+    }
+  }, [selectedAnimation, reviewData]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -282,10 +296,12 @@ const ReviewPage3 = () => {
           )}
         </S.DropdownContainer3>
 
+        {/* 애니메이션에 따른 해시태그 동적 표시 */}
         <S.TagContainer>
-          <S.Tag>#다이에이</S.Tag>
-          <S.Tag>#고시엔</S.Tag>
-          <S.Tag>#아구에니</S.Tag>
+          {selectedAnimation &&
+            reviewData?.animationGroups
+              .find((group) => group.animationId === selectedAnimation.animationId)
+              ?.hashTags.map((tag) => <S.Tag key={tag.hashTagId}>#{tag.name}</S.Tag>)}
         </S.TagContainer>
       </S.NavigationWrapper>
 
@@ -313,7 +329,7 @@ const ReviewPage3 = () => {
         </S.BHeader>
 
         <S.ReviewList>
-          {reviewData.animationGroups.map((group: AnimationGroup) => (
+          {filteredReviews.map((group) => (
             <div key={group.animationId}>
               <h3>{group.animationName}</h3>
               {group.reviews.map((review) => (

--- a/src/pages/ReviewPage4.tsx
+++ b/src/pages/ReviewPage4.tsx
@@ -289,7 +289,7 @@ const ReviewPage4 = () => {
     }
   }, [placeId, isLoggedIn, selectedAnimation, inputRating, reviewText, dispatch, loadData]);
 
-  // 리액션 핸들러
+  // 리액션 핸들러 (수정됨)
   const handleReaction = useCallback(
     async (reviewId: number, reactionType: 0 | 1) => {
       if (!isLoggedIn || !placeId) {
@@ -305,8 +305,22 @@ const ReviewPage4 = () => {
 
       try {
         const response = await addShortReviewReaction(Number(placeId), reviewId, reactionType);
+
         if (response.isSuccess) {
-          await loadData();
+          // 로컬 상태 직접 업데이트
+          setReviews((prevReviews) =>
+            prevReviews.map((review) =>
+              review.id === reviewId
+                ? {
+                    ...review,
+                    likes: response.result.likes,
+                    dislikes: response.result.dislikes,
+                    isLiked: response.result.isLiked,
+                    isDisliked: response.result.isDisliked,
+                  }
+                : review,
+            ),
+          );
         }
       } catch (error) {
         if (axios.isAxiosError(error)) {
@@ -318,7 +332,7 @@ const ReviewPage4 = () => {
         }
       }
     },
-    [isLoggedIn, placeId, dispatch, loadData],
+    [isLoggedIn, placeId, dispatch],
   );
 
   // 리뷰 아이템 렌더링

--- a/src/pages/ReviewPage5.tsx
+++ b/src/pages/ReviewPage5.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAppSelector } from '@/hooks/reduxHooks';
 import { openLoginModal } from '@/store/slices/modalSlice';
 import { saveRoute } from '@/api/review/route';
@@ -9,8 +10,6 @@ import * as S from '../styles/review/ReviewPage.style';
 import { ReviewDetail, ReviewType } from '@/types/review/review';
 import { RouteData } from '@/types/review/route';
 import { RouteSource } from '@/types/map/routeSource';
-//import axios from 'axios';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 const ReviewPage5 = () => {
   const navigate = useNavigate();
@@ -20,6 +19,8 @@ const ReviewPage5 = () => {
   const [reviewData, setReviewData] = useState<ReviewDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showPurchasePrompt, setShowPurchasePrompt] = useState(false);
+  const [showPurchaseModal, setShowPurchaseModal] = useState(false);
   const { reviewId } = useParams();
   const [searchParams] = useSearchParams();
   const type = (searchParams.get('type') as ReviewType) || 'PLACE';
@@ -33,6 +34,11 @@ const ReviewPage5 = () => {
         const response = await getReviewDetail(Number(reviewId), type);
         if (response.isSuccess) {
           setReviewData(response.result);
+
+          // price > 0이면 구매 프롬프트 표시
+          if (response.result.price > 0) {
+            setShowPurchasePrompt(true);
+          }
         } else {
           setError(response.message);
         }
@@ -57,12 +63,11 @@ const ReviewPage5 = () => {
 
     try {
       setIsSaving(true);
-      // Convert API route items to RouteData format
       const routeData: RouteData[] = reviewData.route.routeItems.map((item) => ({
         id: item.placeId,
         order: item.itemOrder,
         name: item.name,
-        description: '', // Add description if needed from your data
+        description: '',
       }));
 
       const response = await saveRoute(reviewData.reviewId, routeData);
@@ -80,6 +85,29 @@ const ReviewPage5 = () => {
     }
   };
 
+  const handlePurchaseReview = () => {
+    setShowPurchasePrompt(false);
+    setShowPurchaseModal(true);
+  };
+
+  const confirmPurchase = async () => {
+    try {
+      // 실제 구매 API 호출 (백엔드에서 제공)
+      // const purchaseResponse = await purchaseReview(reviewData.reviewId);
+
+      // 구매 후 다시 리뷰 상세 정보 불러오기
+      const response = await getReviewDetail(Number(reviewId), type);
+      if (response.isSuccess) {
+        setReviewData(response.result);
+        setShowPurchaseModal(false);
+        setShowPurchasePrompt(false);
+      }
+    } catch (error) {
+      console.error('구매 중 오류:', error);
+      alert('후기 구매 중 오류가 발생했습니다.');
+    }
+  };
+
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>{error}</div>;
   if (!reviewData) return <div>후기를 찾을 수 없습니다.</div>;
@@ -88,69 +116,155 @@ const ReviewPage5 = () => {
     (a, b) => a.itemOrder - b.itemOrder,
   );
 
+  const isPaidReview = reviewData.price > 0;
+
   return (
-    <S.Container>
-      <S.BreadcrumbNav>
-        후기 {'>'} {reviewData.animationName}
-      </S.BreadcrumbNav>
+    <>
+      {/* 구매 프롬프트 모달 */}
+      {showPurchasePrompt && isPaidReview && (
+        <S.ModalOverlay>
+          <S.ModalContent>
+            <p>유료 게시물입니다. 열람을 위해서는 구매가 필요합니다.</p>
+            <S.Button onClick={handlePurchaseReview}>후기 구매하기</S.Button>
+          </S.ModalContent>
+        </S.ModalOverlay>
+      )}
 
-      <S.WhiteContainer>
-        <S.HeaderContainer>
-          <S.PostTitle>{reviewData.title}</S.PostTitle>
-          <S.MetaInfo>
-            <S.Avatar>
-              <img
-                src={reviewData.profileImage?.fileUrl || defaultProfileImage}
-                alt={`${reviewData.userName}의 프로필`}
-              />
-            </S.Avatar>
-            <S.UserInfo>
-              <S.Username>{reviewData.userName}</S.Username>
-              <S.Date>{new Date(reviewData.createdAt).toLocaleDateString()}</S.Date>
-            </S.UserInfo>
-          </S.MetaInfo>
-        </S.HeaderContainer>
+      {/* 구매 확인 모달 */}
+      {showPurchaseModal && (
+        <S.ModalOverlay>
+          <S.PurchaseModal>
+            <h2>후기 구매</h2>
+            <div>
+              <p>현재 보유 포인트: 10000P</p>
+              <p>후기 가격: {reviewData.price}P</p>
+              <p>구매 후 포인트: {10000 - reviewData.price}P</p>
+            </div>
+            <S.Button onClick={confirmPurchase}>구매하기</S.Button>
+            <S.Button onClick={() => setShowPurchaseModal(false)}>취소</S.Button>
+          </S.PurchaseModal>
+        </S.ModalOverlay>
+      )}
 
-        <S.ContentContainer>
-          <S.MainContent>
-            <S.ReviewContext>{reviewData.content}</S.ReviewContext>
-            <S.MapContainer>
-              {reviewData.reviewImages.map((image) => (
-                <img key={image.id} src={image.fileUrl} alt={image.fileName} />
-              ))}
-            </S.MapContainer>
-          </S.MainContent>
+      <S.Container>
+        <S.BreadcrumbNav>
+          후기 {'>'} {reviewData.animationName}
+        </S.BreadcrumbNav>
 
-          <S.SideContent>
-            <S.SaveRouteButton onClick={handleSaveRoute} disabled={isSaving}>
-              {isSaving ? '저장 중...' : '루트 저장하기'}
-            </S.SaveRouteButton>
-            <S.RouteList>
-              {sortedRouteItems.map((route) => (
-                <S.RouteItem key={route.placeId}>
-                  <S.RouteNumber>{route.itemOrder}</S.RouteNumber>
-                  <S.RouteName>{route.name}</S.RouteName>
-                </S.RouteItem>
-              ))}
-            </S.RouteList>
-            <S.RouteButtonContainer>
-              <S.Button
-                onClick={() =>
-                  navigate(`/route/${reviewData.route.routeId}`, {
-                    state: {
-                      routeSource: RouteSource.REVIEW,
-                    },
-                  })
-                }
-              >
-                루트 지도에서 보기
-              </S.Button>
-              <S.SupportButton>후기 구매하기</S.SupportButton>
-            </S.RouteButtonContainer>
-          </S.SideContent>
-        </S.ContentContainer>
-      </S.WhiteContainer>
-    </S.Container>
+        <S.WhiteContainer>
+          <S.HeaderContainer>
+            <S.PostTitle>{reviewData.title}</S.PostTitle>
+            <S.MetaInfo>
+              <S.Avatar>
+                <img
+                  src={reviewData.profileImage?.fileUrl || defaultProfileImage}
+                  alt={`${reviewData.userName}의 프로필`}
+                />
+              </S.Avatar>
+              <S.UserInfo>
+                <S.Username>{reviewData.userName}</S.Username>
+                <S.Date>{new Date(reviewData.createdAt).toLocaleDateString()}</S.Date>
+              </S.UserInfo>
+            </S.MetaInfo>
+          </S.HeaderContainer>
+
+          {isPaidReview ? (
+            <S.BlurredContent $isPaid={showPurchasePrompt}>
+              {showPurchasePrompt && (
+                <S.PurchaseOverlay>
+                  <S.Button onClick={handlePurchaseReview}>후기 구매하기</S.Button>
+                </S.PurchaseOverlay>
+              )}
+
+              <S.ContentContainer>
+                <S.MainContent>
+                  <S.ReviewContext>
+                    {showPurchasePrompt
+                      ? '유료 게시물입니다. 구매 후 열람 가능합니다.'
+                      : reviewData.content}
+                  </S.ReviewContext>
+                  <S.MapContainer>
+                    {reviewData.reviewImages.map((image) => (
+                      <img key={image.id} src={image.fileUrl} alt={image.fileName} />
+                    ))}
+                  </S.MapContainer>
+                </S.MainContent>
+
+                <S.SideContent>
+                  <S.SaveRouteButton onClick={handleSaveRoute} disabled={isSaving}>
+                    {isSaving ? '저장 중...' : '루트 저장하기'}
+                  </S.SaveRouteButton>
+                  <S.RouteList>
+                    {sortedRouteItems.map((route) => (
+                      <S.RouteItem key={route.placeId}>
+                        <S.RouteNumber>{route.itemOrder}</S.RouteNumber>
+                        <S.RouteName>{route.name}</S.RouteName>
+                      </S.RouteItem>
+                    ))}
+                  </S.RouteList>
+                  <S.RouteButtonContainer>
+                    <S.Button
+                      onClick={() =>
+                        navigate(`/route/${reviewData.route.routeId}`, {
+                          state: {
+                            routeSource: RouteSource.REVIEW,
+                          },
+                        })
+                      }
+                    >
+                      루트 지도에서 보기
+                    </S.Button>
+                    {showPurchasePrompt && (
+                      <S.SupportButton onClick={handlePurchaseReview}>
+                        후기 구매하기
+                      </S.SupportButton>
+                    )}
+                  </S.RouteButtonContainer>
+                </S.SideContent>
+              </S.ContentContainer>
+            </S.BlurredContent>
+          ) : (
+            <S.ContentContainer>
+              <S.MainContent>
+                <S.ReviewContext>{reviewData.content}</S.ReviewContext>
+                <S.MapContainer>
+                  {reviewData.reviewImages.map((image) => (
+                    <img key={image.id} src={image.fileUrl} alt={image.fileName} />
+                  ))}
+                </S.MapContainer>
+              </S.MainContent>
+
+              <S.SideContent>
+                <S.SaveRouteButton onClick={handleSaveRoute} disabled={isSaving}>
+                  {isSaving ? '저장 중...' : '루트 저장하기'}
+                </S.SaveRouteButton>
+                <S.RouteList>
+                  {sortedRouteItems.map((route) => (
+                    <S.RouteItem key={route.placeId}>
+                      <S.RouteNumber>{route.itemOrder}</S.RouteNumber>
+                      <S.RouteName>{route.name}</S.RouteName>
+                    </S.RouteItem>
+                  ))}
+                </S.RouteList>
+                <S.RouteButtonContainer>
+                  <S.Button
+                    onClick={() =>
+                      navigate(`/route/${reviewData.route.routeId}`, {
+                        state: {
+                          routeSource: RouteSource.REVIEW,
+                        },
+                      })
+                    }
+                  >
+                    루트 지도에서 보기
+                  </S.Button>
+                </S.RouteButtonContainer>
+              </S.SideContent>
+            </S.ContentContainer>
+          )}
+        </S.WhiteContainer>
+      </S.Container>
+    </>
   );
 };
 

--- a/src/pages/ReviewPage6.tsx
+++ b/src/pages/ReviewPage6.tsx
@@ -100,7 +100,7 @@ const ReviewPage6 = () => {
   return (
     <S.Container>
       <S.ProfileSection>
-        <S.BackButton onClick={() => navigate(-1)}>
+        <S.BackButton onClick={() => navigate('/')}>
           <img src={vector} alt="뒤로가기 아이콘" />
         </S.BackButton>
         <S.DiamondLeft src={diamondLeft} alt="Left Diamond" />

--- a/src/pages/ReviewPage7.tsx
+++ b/src/pages/ReviewPage7.tsx
@@ -172,6 +172,7 @@ const ReviewPage7 = () => {
         content,
         reviewType: selectedReviewType === '이벤트 후기' ? 'EVENT' : 'PLACE',
         animeId: selectedAnimationId,
+        visibility: selectedVisibility === '전체 열람가능' ? 'PUBLIC' : 'PURCHASERS_ONLY',
         routeItems: locations
           .filter((location) => location.name.trim() !== '')
           .map((location, index) => ({

--- a/src/styles/review/ReviewPage.style.ts
+++ b/src/styles/review/ReviewPage.style.ts
@@ -1340,3 +1340,45 @@ export const AddLocationButton = styled.button`
     background-color: #e0e0e0;
   }
 `;
+
+export const ModalOverlay5 = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+export const ModalContent5 = styled.div`
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
+  width: 400px;
+  text-align: center;
+`;
+
+export const PurchaseModal = styled(ModalContent)`
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+`;
+
+export const BlurredContent = styled.div<{ $isPaid: boolean }>`
+  filter: ${(props) => (props.$isPaid ? 'blur(10px)' : 'none')};
+  pointer-events: ${(props) => (props.$isPaid ? 'none' : 'auto')};
+  position: relative;
+`;
+
+export const PurchaseOverlay = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  z-index: 10;
+`;

--- a/src/styles/review/ReviewPage.style.ts
+++ b/src/styles/review/ReviewPage.style.ts
@@ -982,7 +982,7 @@ export const BackButton = styled.button`
   font-size: 20px;
   cursor: pointer;
   position: absolute;
-  left: -710px;
+  left: -600px;
 `;
 
 export const ProfileSection = styled.div`

--- a/src/styles/review/ReviewPage.style.ts
+++ b/src/styles/review/ReviewPage.style.ts
@@ -1368,9 +1368,9 @@ export const PurchaseModal = styled(ModalContent)`
   gap: 15px;
 `;
 
-export const BlurredContent = styled.div<{ $isPaid: boolean }>`
-  filter: ${(props) => (props.$isPaid ? 'blur(10px)' : 'none')};
-  pointer-events: ${(props) => (props.$isPaid ? 'none' : 'auto')};
+export const BlurredContent = styled.div<{ $isBlurred: boolean }>`
+  filter: ${(props) => (props.$isBlurred ? 'blur(10px)' : 'none')};
+  pointer-events: ${(props) => (props.$isBlurred ? 'none' : 'auto')};
   position: relative;
 `;
 

--- a/src/types/event/short-review.ts
+++ b/src/types/event/short-review.ts
@@ -1,26 +1,9 @@
 // types/event/short-review.ts
-export interface ShortReviewRequest {
+
+export interface User {
   userId: number;
-  rating: number;
-  content: string;
-}
-
-export interface UpdateShortReviewRequest {
-  rating: number;
-  content: string;
-}
-
-export interface ShortReviewResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: {
-    id: number;
-    reviewId: number;
-    content: string;
-    rating: number;
-    createdAt: string;
-  };
+  nickname: string;
+  profileImage: string;
 }
 
 export interface ProfileImage {
@@ -30,12 +13,22 @@ export interface ProfileImage {
   fileUrl: string;
 }
 
+export interface ShortReviewRequest {
+  rating: number;
+  content: string;
+}
+
+export interface UpdateShortReviewRequest {
+  rating: number;
+  content: string;
+}
+
 export interface EventShortReview {
   id: number;
+  user: User;
   content: string;
   rating: number;
   profileImage: ProfileImage;
-  username: string;
   likes: number;
   dislikes: number;
   userVote?: 'like' | 'dislike' | null;
@@ -49,6 +42,19 @@ export interface EventShortReviewListResponse {
     eventShortReviewList: EventShortReview[];
     currentPage: number;
     totalPages: number;
+  };
+}
+
+export interface ShortReviewResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    id: number;
+    reviewId: number;
+    content: string;
+    rating: number;
+    createdAt: string;
   };
 }
 

--- a/src/types/event/short-review.ts
+++ b/src/types/event/short-review.ts
@@ -65,3 +65,20 @@ export interface UpdateShortReviewResponse {
   message: string;
   result: string;
 }
+
+export interface ShortReviewReactionRequest {
+  reactionType: 0 | 1; // 0: dislike, 1: like
+}
+
+export interface ShortReviewReactionResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    reviewId: number;
+    likes: number;
+    dislikes: number;
+    isLiked: boolean;
+    isDisliked: boolean;
+  };
+}

--- a/src/types/review/PlaceReview.ts
+++ b/src/types/review/PlaceReview.ts
@@ -18,9 +18,15 @@ export interface Review {
   type: string;
 }
 
+export interface HashTag {
+  hashTagId: number;
+  name: string;
+}
+
 export interface AnimationGroup {
   animationId: number;
   animationName: string;
+  hashTags: HashTag[];
   reviews: Review[];
   totalReviews: number;
 }

--- a/src/types/review/WriteReview.ts
+++ b/src/types/review/WriteReview.ts
@@ -15,6 +15,7 @@ export interface WriteReviewRequest {
   content: string;
   reviewType: 'EVENT' | 'PLACE';
   animeId: number;
+  visibility: 'PUBLIC' | 'PURCHASERS_ONLY'; // 새로 추가
   routeItems: RouteItem[];
 }
 

--- a/src/types/review/point.ts
+++ b/src/types/review/point.ts
@@ -1,0 +1,13 @@
+// types/review/point.ts
+
+export interface PointBalance {
+  userId: string;
+  point: number;
+}
+
+export interface PointBalanceResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: PointBalance;
+}

--- a/src/types/review/review.ts
+++ b/src/types/review/review.ts
@@ -26,6 +26,7 @@ export interface ReviewDetail {
   title: string;
   view: number;
   content: string;
+  price: number; // 0이면 무료, 0 초과면 유료
   reviewImages: ImageData[];
   userName: string;
   profileImage: ImageData;


### PR DESCRIPTION
- feat(119): 이벤트 상세 페이지 이동 , 애니메이션에 따른 후기 및 태그 변경, 유료 무료 api 추가

## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 이벤트 상세 페이지 이동
- 애니메이션에 따른 후기 및 태그 변경
- 유료 무료 변경된 api 추가
- price 0 아닐 때 팝업창 나오게 하기

  <br/>

## 이미지 첨부


<br/>

## 🔧 앞으로의 과제

- 디자인 수정
- reviewpage4 좋아요 싫어요
- 후기 조회 및 작성 시 구매 관련 부분 api 수정 반영하기
- 이벤트 페이지 수정 삭제 부분 수정
- 팝업창에서 현재 포인트 연동해서 뜨게하기
- 이벤트 페이지 한 줄 리뷰 아이디 api 수정 된거 반영하기

  <br/>

## ➕ 이슈 링크

- #119 

<br/>
